### PR TITLE
wdl work with jaws

### DIFF
--- a/cmds
+++ b/cmds
@@ -1,0 +1,2 @@
+# test cmd
+java -Dconfig.file=cromwell_shifter.conf -Dbackend.providers.Local.config.dockerRoot=$(pwd)/cromwell-executions -jar /global/cfs/projectdirs/jaws/cromwell/cromwell.jar run rqcfilter_cori.wdl -i test-inputs.json

--- a/cromwell_shifter.conf
+++ b/cromwell_shifter.conf
@@ -1,0 +1,105 @@
+include required(classpath("application"))
+
+webservice
+{
+  port = 50010
+}
+
+system
+{
+  abort-jobs-on-terminate = false
+  graceful-server-shutdown = true
+  workflow-restart = true
+  max-concurrent-workflows = 100000
+  max-workflow-launch-count = 100000
+  new-workflow-poll-rate = 1
+  number-of-workflow-log-copy-workers = 20
+  number-of-cache-read-workers = 50
+}
+
+workflow-options
+{
+  workflow-log-dir: "cromwell-workflow-logs"
+  workflow-log-temporary: false
+  workflow-failure-mode: "ContinueWhilePossible"
+  default
+  {
+    workflow-type: WDL
+    workflow-type-version: "draft-2"
+  }
+}
+
+call-caching
+{
+  enabled = true
+  invalidate-bad-cache-result = true
+}
+
+# this is required for shifter to find image from its registry.
+docker {
+    hash-lookup {
+        enabled = false
+    }
+}
+
+backend
+{
+  default = "Local"
+
+  providers
+  {
+
+    Local
+    {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+
+      config
+      {
+        concurrent-job-limit = 7
+        run-in-background = true
+        #temporary-directory = "`mktemp -d \"/global/cscratch1/sd/jaws_jtm/dev/cromwell-tmp\"/tmp.XXXXXX`"
+
+        # The list of possible runtime custom attributes.
+        runtime-attributes = """
+        String? docker
+        """
+
+        # Submit string when there is no "docker" runtime attribute.
+        submit = "/usr/bin/env bash ${script}"
+
+        submit-docker = """
+            LOOKUP=$(shifterimg lookup ${docker})
+            if [[ ! $LOOKUP ]]; then
+                shifterimg pull ${docker}
+            fi
+
+            shifter --image=${docker} \
+            -V /global/cscratch1/sd/jaws/refdata:/refdata \
+            ${job_shell} ${script}
+        """
+
+		dockerRoot = /cromwell-executions
+
+        filesystems
+        {
+          local
+          {
+            localization: [ "soft-link", "copy" ]
+
+            caching {
+              duplication-strategy: [ "soft-link", "file" ]
+              hashing-strategy: "file"
+            }
+          }
+        }
+
+        default-runtime-attributes
+        {
+          failOnStderr: false
+          continueOnReturnCode: 0
+        }
+      }
+    }
+
+  }
+}

--- a/rqcfilter_cori.wdl
+++ b/rqcfilter_cori.wdl
@@ -1,0 +1,59 @@
+workflow jgi_rqcfilter {
+    Array[File] input_files
+    String bbtools_container="microbiomedata/bbtools:38.44"
+    String database="/databases/nmdc/RQCFilterData"
+
+    scatter(file in input_files) {
+        call rqcfilter{
+             input:  input_file=file, container=bbtools_container, database=database
+        }
+    }
+
+    parameter_meta {
+        input_files: "illumina paired-end interleaved fastq files"
+        outdir: "The final output directory path"
+        database : "database path to RQCFilterData directory"
+        clean_fastq_files: "after QC fastq files"
+    }
+    meta {
+        author: "Chienchi Lo, B10, LANL"
+        email: "chienchi@lanl.gov"
+        version: "1.0.0"
+    }
+}
+
+task rqcfilter {
+     File input_file
+     String container
+     String database
+     String filename_outlog="stdout.log"
+     String filename_errlog="stderr.log"
+     String filename_stat="filtered/filterStats.txt"
+     String filename_stat2="filtered/filterStats2.txt"
+     String dollar="$"
+     String num_threads=8
+
+     runtime {
+        docker: container
+        time: "01:00:00"
+        mem: "40G"
+        poolname: "nmdc_readqc_test"
+        shared: 0
+        node: 1
+        nwpn: 1
+     }
+
+     command {
+        #sleep 30
+        export TIME="time result\ncmd:%C\nreal %es\nuser %Us \nsys  %Ss \nmemory:%MKB \ncpu %P"
+        set -eo pipefail
+        rqcfilter2.sh -Xmx35g threads=${num_threads} jni=t in=${input_file} path=filtered rna=f trimfragadapter=t qtrim=r trimq=0 maxns=3 maq=3 minlen=51 mlf=0.33 phix=t removehuman=t removedog=t removecat=t removemouse=t khist=t removemicrobes=t sketch kapa=t clumpify=t tmpdir= barcodefilter=f trimpolyg=5 usejni=f rqcfilterdata=${database} > >(tee -a ${filename_outlog}) 2> >(tee -a ${filename_errlog} >&2)
+     }
+     output {
+            File stdout = filename_outlog
+            File stderr = filename_errlog
+            File stat = filename_stat
+            File stat2 = filename_stat2
+     }
+}
+

--- a/rqcfilter_jgi.wdl
+++ b/rqcfilter_jgi.wdl
@@ -1,0 +1,61 @@
+workflow jgi_rqcfilter {
+    Array[File] input_files
+    String bbtools_container="microbiomedata/bbtools:38.44"
+    String database="/refdata/nmdc/RQCFilterData"
+
+    scatter(file in input_files) {
+        call rqcfilter{
+             input:  input_file=file, container=bbtools_container, database=database
+        }
+    }
+
+    parameter_meta {
+        input_files: "illumina paired-end interleaved fastq files"
+  	    outdir: "The final output directory path"
+        database : "database path to RQCFilterData directory"
+        clean_fastq_files: "after QC fastq files"
+    }
+    meta {
+        author: "Chienchi Lo, B10, LANL"
+        email: "chienchi@lanl.gov"
+        version: "1.0.0"
+    }
+}
+
+task rqcfilter {
+     File input_file
+     String container
+     String database
+     String filename_outlog="stdout.log"
+     String filename_errlog="stderr.log"
+     String filename_stat="filtered/filterStats.txt"
+     String filename_stat2="filtered/filterStats2.txt"
+     String dollar="$"
+     String num_threads=8
+
+     runtime {
+        docker: container
+        time: "05:00:00"
+        mem: "240G"
+        poolname: "nmdc_readqc_test"
+        shared: 0
+        node: 1
+        nwpn: 1
+        constraint: "lr3_c32,jgi_m256"
+        partition: "lr3"
+        account: "lr_jgicloud"
+        qos: "condo_jgicloud"
+     }
+
+     command {
+        export TIME="time result\ncmd:%C\nreal %es\nuser %Us \nsys  %Ss \nmemory:%MKB \ncpu %P"
+        set -eo pipefail
+        rqcfilter2.sh -Xmx230g threads=${num_threads} jni=t in=${input_file} path=filtered rna=f trimfragadapter=t qtrim=r trimq=0 maxns=3 maq=3 minlen=51 mlf=0.33 phix=t removehuman=t removedog=t removecat=t removemouse=t khist=t removemicrobes=t sketch kapa=t clumpify=t tmpdir= barcodefilter=f trimpolyg=5 usejni=f rqcfilterdata=${database} > >(tee -a ${filename_outlog}) 2> >(tee -a ${filename_errlog} >&2)
+     }
+     output {
+            File stdout = filename_outlog
+            File stderr = filename_errlog
+            File stat = filename_stat
+            File stat2 = filename_stat2
+     }
+}

--- a/rqcfilter_orig.wdl
+++ b/rqcfilter_orig.wdl
@@ -1,0 +1,88 @@
+workflow jgi_rqcfilter {
+    Array[File] input_files
+    String? outdir
+    String bbtools_container="microbiomedata/bbtools:38.44"
+    String database="/refdata"
+
+    scatter(file in input_files) {
+        call rqcfilter{
+             input:  input_file=file, container=bbtools_container, database=database
+        }
+    }
+  
+    # rqcfilter.stat implicit as Array because of scatter 
+    call make_output {
+       	input: outdir= outdir, rqcfilter_output=rqcfilter.stat
+    }
+
+    output{
+        Array[File] clean_fastq_files = make_output.fastq_files
+    }
+    
+    parameter_meta {
+        input_files: "illumina paired-end interleaved fastq files"
+	outdir: "The final output directory path"
+        database : "database path to RQCFilterData directory"
+        clean_fastq_files: "after QC fastq files"
+    }
+    meta {
+        author: "Chienchi Lo, B10, LANL"
+        email: "chienchi@lanl.gov"
+        version: "1.0.0"
+    }
+}
+
+task rqcfilter {
+     File input_file
+     String container
+     String database
+     String filename_outlog="stdout.log"
+     String filename_errlog="stderr.log"
+     String filename_stat="filtered/filterStats.txt"
+     String filename_stat2="filtered/filterStats2.txt"
+     String dollar="$"
+     runtime {
+            docker: container
+            memory: "120 GiB"
+	    cpu:  16
+            database: database
+     }
+
+     command {
+        #sleep 30
+        export TIME="time result\ncmd:%C\nreal %es\nuser %Us \nsys  %Ss \nmemory:%MKB \ncpu %P"
+        set -eo pipefail
+        rqcfilter2.sh -Xmx105g threads=${dollar}(grep "model name" /proc/cpuinfo | wc -l) jni=t in=${input_file} path=filtered rna=f trimfragadapter=t qtrim=r trimq=0 maxns=3 maq=3 minlen=51 mlf=0.33 phix=t removehuman=t removedog=t removecat=t removemouse=t khist=t removemicrobes=t sketch kapa=t clumpify=t tmpdir= barcodefilter=f trimpolyg=5 usejni=f rqcfilterdata=/databases/RQCFilterData  > >(tee -a ${filename_outlog}) 2> >(tee -a ${filename_errlog} >&2)
+     }
+     output {
+            File stdout = filename_outlog
+            File stderr = filename_errlog
+            File stat = filename_stat
+            File stat2 = filename_stat2
+     }
+}
+
+task make_output{
+ 	String outdir
+	Array[String] rqcfilter_output
+ 
+ 	command{
+			for i in ${sep=' ' rqcfilter_output}
+			do
+				rqcfilter_path=`dirname $i`
+				prefix=$(basename $rqcfilter_path/*.anqdpht.fastq.gz .anqdpht.fastq.gz)
+ 				mkdir -p ${outdir}/$prefix
+				mv -f $rqcfilter_path/* ${outdir}/$prefix
+				echo ${outdir}/$prefix/$prefix.anqdpht.fastq.gz
+			done
+ 			chmod 764 -R ${outdir}
+ 	}
+	runtime {
+            memory: "1 GiB"
+            cpu:  1
+        }
+	output{
+		Array[String] fastq_files = read_lines(stdout())
+	}
+}
+

--- a/test-inputs.json
+++ b/test-inputs.json
@@ -1,0 +1,6 @@
+{
+    "jgi_rqcfilter.input_files": [
+        "/global/cscratch1/sd/sulsj/metagenome_data/ficus/12122.1.237730.TGCAGCT-CTTAATA.fastq.gz"
+    ],
+    "jgi_rqcfilter.database": "/refdata/nmdc/RQCFilterData"
+}


### PR DESCRIPTION
I added JAWS related dependencies for the runtime{} section for each task.  

There are two versions of the WDL, one for cori and one for jgi  site (i.e. rqcfilter_cori.wdl and rqcfilter_jgi.wdl). 

The `cmd` file shows which command I used for testing the WDL outside of JAWS.  This workflow has also been demonstrated to work in JAWS.