### PR TITLE
54 add support to fetch data based on a sra identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,26 +31,28 @@ This workflow performs quality control on long reads from PacBio. The workflow p
 1. the path to the interleaved fastq file (longreads and shortreads) 
 2. forwards reads fastq file (when input_interleaved is false)
 3. reverse reads fastq file (when input_interleaved is false)  
-4. project id
-5. if the input is interleaved (boolean) 
-6. if the input is shortreads (boolean)
+4. NCBI SRA accessions (mutually exclusive to above inputs. ex: SRR6324898)
+5. project id
+6. if the input is interleaved (boolean) 
+7. if the input is shortreads (boolean)
 
 ```
 {
 	"rqcfilter.input_files": ["https://portal.nersc.gov/project/m3408//test_data/smalltest.int.fastq.gz"],
-    	"rqcfilter.input_fq1": [],
-    	"rqcfilter.input_fq2": [],
-    	"rqcfilter.proj": "nmdc:xxxxxxx",
+    "rqcfilter.input_fq1": [],
+    "rqcfilter.input_fq2": [],
+    "rqcfilter.accessions": [],
+    "rqcfilter.proj": "nmdc:xxxxxxx",
    	"rqcfilter.interleaved": true,
-    	"rqcfilter.shortRead": true
+    "rqcfilter.shortRead": true
 }
 ```
 
 ## Output files
 
-The output will have one directory named by prefix of the fastq input file and a bunch of output files, including statistical numbers, status log and a shell script to reproduce the steps etc. 
+The output will have one directory named by prefix of the output files, including statistical numbers, status log and readsQC.info. When the input consists of SRA accessions (e.g., "rqcfilter.accessions": ["SRR34992488"]), the workflow will also output the corresponding FASTQ files (e.g., SRR34992488_1.fastq.gz and SRR34992488_2.fastq.gz) in addition to the standard output files.
 
-The main QC fastq output is named by prefix.anqdpht.fast.gz. 
+The main QC fastq output is named by prefix_filtered.fastq.gz. 
 
 ```
 * Short Reads

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -128,9 +128,10 @@ A `JSON file <https://github.com/microbiomedata/ReadsQC/blob/documentation/input
 1. the path to the interleaved fastq file (longreads and shortreads) 
 2. forwards reads fastq file (when input_interleaved is false)
 3. reverse reads fastq file (when input_interleaved is false)  
-4. project id
-5. if the input is interleaved (boolean) 
-6. if the input is shortreads (boolean)
+4. NCBI SRA accessions (mutually exclusive to above inputs. ex: SRR34992488)
+5. project id
+6. if the input is interleaved (boolean) 
+7. if the input is shortreads (boolean)
 
 
 An example input JSON file is shown below:
@@ -139,12 +140,13 @@ An example input JSON file is shown below:
 .. code-block:: JSON
 
     {
-	"rqcfilter.input_files": ["https://portal.nersc.gov/cfs/m3408/test_data/smalltest.int.fastq.gz"],
-    	"rqcfilter.input_fq1": [],
-    	"rqcfilter.input_fq2": [],
-    	"rqcfilter.proj": "nmdc:xxxxxxx",
-   	"rqcfilter.interleaved": true,
-    	"rqcfilter.shortRead": true
+        "rqcfilter.input_files": ["https://portal.nersc.gov/cfs/m3408/test_data/smalltest.int.fastq.gz"],
+        "rqcfilter.input_fq1": [],
+        "rqcfilter.input_fq2": [],
+        "rqcfilter.accessions": [],
+        "rqcfilter.proj": "nmdc:xxxxxxx",
+        "rqcfilter.interleaved": true,
+        "rqcfilter.shortRead": true
     }
 
 .. note::
@@ -156,7 +158,7 @@ An example input JSON file is shown below:
 
 	**Non-Interleaved**: :literal:`"rqcfilter.input_fq1": ["first-int-R1.fastq","second-int-R1.fastq"], "rqcfilter.input_fq2": ["first-int-R2.fastq","second-int-R2.fastq"]`
 
-	**Long-Reads**: :literal:`"rqcfilter.input_files": ["PacBio-int.fastq"]`
+	**Long-Reads**: :literal:`"rqcfilter.input_files": ["PacBio.fastq"]`
 
 
 Output
@@ -199,15 +201,20 @@ FileName                              Description
 nmdc_xxxxxxx_filtered.fastq.gz        main output (clean data)
 nmdc_xxxxxxx_filterStats.txt	      summary statistics 
 nmdc_xxxxxxx_filterStats2.txt	      more detailed summary statistics
-nmdc_xxxxxxx_readsQC.info	      summary of parameters used in :literal:`BBTools rqcfilter2`
-nmdc_xxxxxxx_qa_stats.json	      summary statistics of output bases, input reads, input bases, output reads
+nmdc_xxxxxxx_readsQC.info	          summary of parameters used in :literal:`BBTools rqcfilter2`
+nmdc_xxxxxxx_qa_stats.json	          summary statistics of output bases, input reads, input bases, output reads
 **Long-Reads**
 nmdc_xxxxxxx_filtered.fastq.gz        main output (clean data)
 nmdc_xxxxxxx_filterStats.txt	      statistics from the :literal:`pbmarkdup` duplicate removal
 nmdc_xxxxxxx_filterStats2.txt	      more detailed summary statistics
-nmdc_xxxxxxx_readsQC.info	      summary of tools and dockers containers used for long-reads QC
-nmdc_xxxxxxx_qa_stats.json	      summary statistics of output bases, input reads, input bases, output reads
+nmdc_xxxxxxx_readsQC.info	          summary of tools and dockers containers used for long-reads QC
+nmdc_xxxxxxx_qa_stats.json	          summary statistics of output bases, input reads, input bases, output reads
 ==================================== ============================================================================
+
+.. note::
+
+    When the input consists of SRA accessions (e.g., "rqcfilter.accessions": ["SRR34992488"]), the workflow will also output the corresponding FASTQ files (e.g., SRR34992488_1.fastq.gz and SRR34992488_2.fastq.gz) in addition to the standard output files.
+
 
 Download the example ReadsQC output for the short-reads Illumina run SRR7877884 (10% subset) `here <https://portal.nersc.gov/cfs/m3408/test_data/SRR7877884/SRR7877884-0.1_MetaG/ReadsQC/>`_.
 

--- a/input.json
+++ b/input.json
@@ -1,7 +1,8 @@
 {
-  "rqcfilter.input_files": [{"Left": "https://portal.nersc.gov/project/m3408//test_data/Ecoli_10x-int.fastq.gz", "Right": "input_file_1.fastq.gz"}],
+  "rqcfilter.input_files": ["https://portal.nersc.gov/project/m3408//test_data/Ecoli_10x-int.fastq.gz"],
   "rqcfilter.input_fq1": [],
   "rqcfilter.input_fq2": [],
+  "rqcfilter.accessions":[],
   "rqcfilter.proj": "nmdc:xxxxxxx",
   "rqcfilter.interleaved": true,
   "rqcfilter.shortRead": true

--- a/longReadsqc.wdl
+++ b/longReadsqc.wdl
@@ -203,7 +203,7 @@ task bbdukEnds {
         ~{"in=" + in_file} \
         ~{"out=" + out_file} 
         
-        grep -v _JAVA_OPTIONS stderr > bbdukEnds_stats.json
+        grep -v _JAVA_OPTIONS stderr | grep -v 'Changed from' > bbdukEnds_stats.json
 
     >>>
 
@@ -243,8 +243,8 @@ task bbdukReads {
         ~{if (defined(reference)) then "ref=" + reference else "ref=/bbmap/resources/PacBioAdapter.fa" } \
         ~{"in=" + in_file} \
         ~{"out=" + out_file} 
-        
-        grep -v _JAVA_OPTIONS stderr >  bbdukReads_stats.json
+
+        grep -v _JAVA_OPTIONS stderr | grep -v 'Changed from' > bbdukReads_stats.json
 
         #echo -e "outputReads\toutputBases" > output_size.txt
         seqtk size ~{out_file} > output_size.txt

--- a/rqcfilter.wdl
+++ b/rqcfilter.wdl
@@ -16,7 +16,7 @@ workflow rqcfilter{
     Boolean?    chastityfilter_flag
   }
 
-    if (length(accessions) > 1) {
+    if (length(accessions) > 0) {
         call sra.sra as sra2fastq {
             input:
                 accessions = accessions
@@ -24,7 +24,7 @@ workflow rqcfilter{
     }
 
     Boolean is_shortReads = select_first([sra2fastq.isIllumina, shortRead])
-    Boolean is_interleaved = if (length(accessions) > 1) then false else interleaved
+    Boolean is_interleaved = if (length(accessions) > 0) then false else interleaved
     Boolean is_Pacbio       = select_first([sra2fastq.isPacBio, !shortRead])
     Boolean unsupported_platform = !(is_shortReads) && !(is_Pacbio)
 
@@ -40,7 +40,7 @@ workflow rqcfilter{
                 input_fq2 = select_first([sra2fastq.output_fq2, input_fq2]),
                 interleaved = is_interleaved,
                 proj = proj,
-                chastityfilter_flag = if (length(accessions) > 1) then false else chastityfilter_flag
+                chastityfilter_flag = if (length(accessions) > 0) then false else chastityfilter_flag
         }
     }
 

--- a/rqcfilter.wdl
+++ b/rqcfilter.wdl
@@ -12,7 +12,7 @@ workflow rqcfilter{
     File?       reference
     String      proj
     Boolean     interleaved
-    Boolean     shortRead_input
+    Boolean     shortRead
     Boolean?    chastityfilter_flag
   }
 
@@ -23,35 +23,55 @@ workflow rqcfilter{
         }
     }
 
-    Boolean shortRead = select_first([sra2fastq.isIllumina, shortRead_input])
+    Boolean is_shortReads = select_first([sra2fastq.isIllumina, shortRead])
+    Boolean is_interleaved = if (length(accessions) > 1) then false else interleaved
+    Boolean is_Pacbio       = select_first([sra2fastq.isPacBio, !shortRead])
+    Boolean unsupported_platform = !(is_shortReads) && !(is_Pacbio)
+
+    if (unsupported_platform) {
+        call UnsupportedPlatformNotice
+    }
     
-    if (shortRead) {
+    if (is_shortReads) {
         call srqc.ShortReadsQC {
             input:
                 input_files = input_files,
-                input_fq1 = input_fq1,
-                input_fq2 = input_fq2,
-                interleaved = interleaved,
+                input_fq1 = select_first([sra2fastq.output_fq1, input_fq1]),
+                input_fq2 = select_first([sra2fastq.output_fq2, input_fq2]),
+                interleaved = is_interleaved,
                 proj = proj,
-                chastityfilter_flag = chastityfilter_flag
+                chastityfilter_flag = if (length(accessions) > 1) then false else chastityfilter_flag
         }
     }
 
-    if (!shortRead) {
+    if (is_Pacbio) {
         call lrqc.LongReadsQC {
             input:
-                file = input_files[0],
+                file = select_first([sra2fastq.outputFiles, input_files])[0],
                 proj = proj,
                 reference = reference
         }
     }
 
     output {
-        Array[File] sra_fastq_files = sra2fastq.outputFiles
-        File? filtered_final = if (shortRead) then ShortReadsQC.filtered_final else LongReadsQC.filtered_final
-        File? filtered_stats_final = if (shortRead) then ShortReadsQC.filtered_stats_final else LongReadsQC.filtered_stats1
-        File? filtered_stats2_final = if (shortRead) then ShortReadsQC.filtered_stats2_final else LongReadsQC.filtered_stats2
-        File? rqc_info = if (shortRead) then ShortReadsQC.rqc_info else LongReadsQC.rqc_info
-        File? stats = if (shortRead) then ShortReadsQC.stats else LongReadsQC.stats
+        Array[File]? sra_fastq_files = sra2fastq.outputFiles
+        File? filtered_final = if (is_shortReads) then ShortReadsQC.filtered_final else LongReadsQC.filtered_final
+        File? filtered_stats_final = if (is_shortReads) then ShortReadsQC.filtered_stats_final else LongReadsQC.filtered_stats1
+        File? filtered_stats2_final = if (is_shortReads) then ShortReadsQC.filtered_stats2_final else LongReadsQC.filtered_stats2
+        File? rqc_info = if (is_shortReads) then ShortReadsQC.rqc_info else LongReadsQC.rqc_info
+        File? stats = if (is_shortReads) then ShortReadsQC.stats else LongReadsQC.stats
+    }
+}
+
+task UnsupportedPlatformNotice {
+    command {
+        echo "ERROR: Only Illumina and PacBio sequencing platforms are supported at this time." >&2
+    }
+    output {
+        String msg = read_string(stdout())
+    }
+    runtime {
+        memory: "1 GiB"
+        cpu: 1
     }
 }

--- a/rqcfilter.wdl
+++ b/rqcfilter.wdl
@@ -17,7 +17,7 @@ workflow rqcfilter{
   }
 
     if (length(accessions) > 1) {
-        call sra.sra2fastq as sra2fastq {
+        call sra.sra as sra2fastq {
             input:
                 accessions = accessions
         }

--- a/rqcfilter.wdl
+++ b/rqcfilter.wdl
@@ -23,7 +23,7 @@ workflow rqcfilter{
         }
     }
 
-    Boolean shortReads = select_first([sra2fastq.isIllumina, shortRead_input])
+    Boolean shortRead = select_first([sra2fastq.isIllumina, shortRead_input])
     
     if (shortRead) {
         call srqc.ShortReadsQC {
@@ -47,6 +47,7 @@ workflow rqcfilter{
     }
 
     output {
+        Array[File] sra_fastq_files = sra2fastq.outputFiles
         File? filtered_final = if (shortRead) then ShortReadsQC.filtered_final else LongReadsQC.filtered_final
         File? filtered_stats_final = if (shortRead) then ShortReadsQC.filtered_stats_final else LongReadsQC.filtered_stats1
         File? filtered_stats2_final = if (shortRead) then ShortReadsQC.filtered_stats2_final else LongReadsQC.filtered_stats2

--- a/rqcfilter.wdl
+++ b/rqcfilter.wdl
@@ -1,19 +1,30 @@
 version 1.0
 import "shortReadsqc.wdl" as srqc
 import "longReadsqc.wdl" as lrqc
+import "sra2fastq.wdl" as sra
 
 workflow rqcfilter{
     input {
     Array[String] input_files
     Array[String] input_fq1
     Array[String] input_fq2
+    Array[String] accessions
     File?       reference
     String      proj
     Boolean     interleaved
-    Boolean     shortRead
+    Boolean     shortRead_input
     Boolean?    chastityfilter_flag
   }
 
+    if (length(accessions) > 1) {
+        call sra.sra2fastq as sra2fastq {
+            input:
+                accessions = accessions
+        }
+    }
+
+    Boolean shortReads = select_first([sra2fastq.isIllumina, shortRead_input])
+    
     if (shortRead) {
         call srqc.ShortReadsQC {
             input:

--- a/shortReadsqc.wdl
+++ b/shortReadsqc.wdl
@@ -144,10 +144,10 @@ task stage_interleave {
             cat $fq2_name  >> ~{target_reads_2}
         done
 
-        reformat.sh -Xmx~{memory}G in1=~{target_reads_1} in2=~{target_reads_2} out=~{output_interleaved}
+        reformat.sh -Xmx~{memory}G trimreaddescription=t in1=~{target_reads_1} in2=~{target_reads_2} out=~{output_interleaved} 
 
         # Validate that the read1 and read2 files are sorted correctly
-        reformat.sh -Xmx~{memory} verifypaired=t in=~{output_interleaved}
+        reformat.sh -Xmx~{memory}G verifypaired=t in=~{output_interleaved}
 
         # Capture the start time
         date --iso-8601=seconds > start.txt

--- a/sra2fastq.wdl
+++ b/sra2fastq.wdl
@@ -36,16 +36,31 @@ task sra2fastq {
      command <<<
 
         sra2fastq.py ~{sep=' ' accessions} ~{"--outdir=" + outdir}  ~{true=" --clean True" false="" clean} ~{" --platform_restrict=" + platform_restrict} ~{" --filesize_restrict=" + filesize_restrict} ~{" --runs_restrict=" + runs_restrict}
-        if compgen -G "~{outdir}"/*metadata.txt > /dev/null && \
-           grep -iq "illumina" "~{outdir}"/*metadata.txt; then
-            echo true > check_illumina.txt
-        else
-            echo false > check_illumina.txt
+        if compgen -G "~{outdir}"/*metadata.txt > /dev/null; then
+            if grep -iq "illumina" "~{outdir}"/*metadata.txt; then
+                echo true > check_illumina.txt
+            else
+                echo false > check_illumina.txt
+            fi
+            if grep -iq "PAIRED" "~{outdir}"/*metadata.txt; then
+                echo true > check_paired.txt
+            else
+                echo false > check_paired.txt
+            fi
+            if grep -iq "PacBio" "~{outdir}"/*metadata.txt; then
+                echo true > check_pacbio.txt
+            else
+                echo false > check_pacbio.txt
+            fi
         fi
     >>>
     output {
         Array[File] outputFiles = glob("~{outdir}/*")
+        Array[File] output_fq1 = glob("~{outdir}/*_1.fastq.gz")
+        Array[File] output_fq2 = glob("~{outdir}/*_2.fastq.gz")
         Boolean isIllumina = read_boolean("check_illumina.txt")
+        Boolean isPaired = read_boolean("check_paired.txt")
+        Boolean isPacBio = read_boolean("check_pacbio.txt")
     }
 
     runtime {

--- a/sra2fastq.wdl
+++ b/sra2fastq.wdl
@@ -36,11 +36,16 @@ task sra2fastq {
      command <<<
 
         sra2fastq.py ~{sep=' ' accessions} ~{"--outdir=" + outdir}  ~{true=" --clean True" false="" clean} ~{" --platform_restrict=" + platform_restrict} ~{" --filesize_restrict=" + filesize_restrict} ~{" --runs_restrict=" + runs_restrict}
-    
+        if compgen -G "~{outdir}"/*metadata.txt > /dev/null && \
+           grep -iq "illumina" "~{outdir}"/*metadata.txt; then
+            echo true > check_illumina.txt
+        else
+            echo false > check_illumina.txt
+        fi
     >>>
     output {
-        Array[File] outputFiles = glob("${outdir}/*")
-        Boolean isIllumina = if (glob("${outdir}/*.fastq.gz").size() > 1) true else false
+        Array[File] outputFiles = glob("~{outdir}/*")
+        Boolean isIllumina = read_boolean("check_illumina.txt")
     }
 
     runtime {

--- a/sra2fastq.wdl
+++ b/sra2fastq.wdl
@@ -21,6 +21,14 @@ workflow sra {
         container = container
 
     }
+    output {
+        Array[File] outputFiles = sra2fastq.outputFiles
+        Array[File] output_fq1 = sra2fastq.output_fq1   
+        Array[File] output_fq2 = sra2fastq.output_fq1
+        Boolean isIllumina = sra2fastq.isIllumina
+        Boolean isPaired = sra2fastq.isPaired
+        Boolean isPacBio = sra2fastq.isPacBio
+    }
 }
 
 task sra2fastq {

--- a/sra2fastq.wdl
+++ b/sra2fastq.wdl
@@ -1,0 +1,52 @@
+version 1.0
+workflow sra {
+    input {
+        Array[String] accessions
+        String outdir = "SRA_Downloaded"
+        Boolean? clean
+        String? platform_restrict
+        Int? filesize_restrict
+        Int? runs_restrict
+        String container = "kaijli/sra2fastq:1.6"
+    }
+
+    call sra2fastq{
+        input:
+        accessions = accessions,
+        outdir = outdir,
+        clean = clean,
+        platform_restrict = platform_restrict,
+        filesize_restrict = filesize_restrict,
+        runs_restrict = runs_restrict,
+        container = container
+
+    }
+}
+
+task sra2fastq {
+    input {
+        Array[String] accessions
+        String outdir
+        Boolean? clean
+        String? platform_restrict
+        Int? filesize_restrict
+        Int? runs_restrict
+        String container
+    }
+     command <<<
+
+        sra2fastq.py ~{sep=' ' accessions} ~{"--outdir=" + outdir}  ~{true=" --clean True" false="" clean} ~{" --platform_restrict=" + platform_restrict} ~{" --filesize_restrict=" + filesize_restrict} ~{" --runs_restrict=" + runs_restrict}
+    
+    >>>
+    output {
+        Array[File] outputFiles = glob("${outdir}/*")
+        Boolean isIllumina = if (glob("${outdir}/*.fastq.gz").size() > 1) true else false
+    }
+
+    runtime {
+        memory: "16 GiB"
+        cpu: 2
+        docker: container
+        continueOnReturnCode: true
+    }
+}

--- a/sra2fastq.wdl
+++ b/sra2fastq.wdl
@@ -7,7 +7,7 @@ workflow sra {
         String? platform_restrict
         Int? filesize_restrict
         Int? runs_restrict
-        String container = "kaijli/sra2fastq:1.6"
+        String container = "ghcr.io/lanl-bioinformatics/edge_sra2fastq:1.6.3"
     }
 
     call sra2fastq{
@@ -22,9 +22,9 @@ workflow sra {
 
     }
     output {
-        Array[File] outputFiles = sra2fastq.outputFiles
-        Array[File] output_fq1 = sra2fastq.output_fq1   
-        Array[File] output_fq2 = sra2fastq.output_fq1
+        Array[String] outputFiles = sra2fastq.outputFiles
+        Array[String] output_fq1 = sra2fastq.output_fq1   
+        Array[String] output_fq2 = sra2fastq.output_fq2
         Boolean isIllumina = sra2fastq.isIllumina
         Boolean isPaired = sra2fastq.isPaired
         Boolean isPacBio = sra2fastq.isPacBio
@@ -44,28 +44,33 @@ task sra2fastq {
      command <<<
 
         sra2fastq.py ~{sep=' ' accessions} ~{"--outdir=" + outdir}  ~{true=" --clean True" false="" clean} ~{" --platform_restrict=" + platform_restrict} ~{" --filesize_restrict=" + filesize_restrict} ~{" --runs_restrict=" + runs_restrict}
-        if compgen -G "~{outdir}"/*metadata.txt > /dev/null; then
-            if grep -iq "illumina" "~{outdir}"/*metadata.txt; then
+        if compgen -G "~{outdir}"/*/*metadata.txt > /dev/null; then
+            if grep -iq "illumina" "~{outdir}"/*/*metadata.txt; then
                 echo true > check_illumina.txt
             else
                 echo false > check_illumina.txt
             fi
-            if grep -iq "PAIRED" "~{outdir}"/*metadata.txt; then
+            if grep -iq "PAIRED" "~{outdir}"/*/*metadata.txt; then
                 echo true > check_paired.txt
             else
                 echo false > check_paired.txt
             fi
-            if grep -iq "PacBio" "~{outdir}"/*metadata.txt; then
+            if grep -iq "PacBio" "~{outdir}"/*/*metadata.txt; then
                 echo true > check_pacbio.txt
             else
                 echo false > check_pacbio.txt
             fi
+        else
+            echo false > check_illumina.txt
+            echo false > check_paired.txt
+            echo false > check_pacbio.txt
         fi
     >>>
     output {
-        Array[File] outputFiles = glob("~{outdir}/*")
-        Array[File] output_fq1 = glob("~{outdir}/*_1.fastq.gz")
-        Array[File] output_fq2 = glob("~{outdir}/*_2.fastq.gz")
+        Array[String] outputFiles = glob("~{outdir}/*/*fastq.gz")
+        Array[String] output_fq1 = glob("~{outdir}/*/*_1.fastq.gz")
+        Array[String] output_fq2 = glob("~{outdir}/*/*_2.fastq.gz")
+        File?   metadata = glob("~{outdir}/*/*metadata.txt")[0]
         Boolean isIllumina = read_boolean("check_illumina.txt")
         Boolean isPaired = read_boolean("check_paired.txt")
         Boolean isPacBio = read_boolean("check_pacbio.txt")

--- a/sra2fastq.wdl
+++ b/sra2fastq.wdl
@@ -25,6 +25,7 @@ workflow sra {
         Array[String] outputFiles = sra2fastq.outputFiles
         Array[String] output_fq1 = sra2fastq.output_fq1   
         Array[String] output_fq2 = sra2fastq.output_fq2
+        Array[String] metadata = sra2fastq.metadata
         Boolean isIllumina = sra2fastq.isIllumina
         Boolean isPaired = sra2fastq.isPaired
         Boolean isPacBio = sra2fastq.isPacBio
@@ -70,7 +71,7 @@ task sra2fastq {
         Array[String] outputFiles = glob("~{outdir}/*/*fastq.gz")
         Array[String] output_fq1 = glob("~{outdir}/*/*_1.fastq.gz")
         Array[String] output_fq2 = glob("~{outdir}/*/*_2.fastq.gz")
-        File?   metadata = glob("~{outdir}/*/*metadata.txt")[0]
+        Array[String] metadata = glob("~{outdir}/*/*metadata.txt")
         Boolean isIllumina = read_boolean("check_illumina.txt")
         Boolean isPaired = read_boolean("check_paired.txt")
         Boolean isPacBio = read_boolean("check_pacbio.txt")


### PR DESCRIPTION
This pull request introduces support for using NCBI SRA accessions as workflow input, allowing users to fetch and process sequencing data directly from SRA in addition to local FASTQ files. The documentation and input examples have been updated to reflect this new capability, and the workflow logic has been enhanced to automatically detect sequencing platform types and handle unsupported platforms gracefully.

**Major new feature: SRA accession input support**

* Added a new subworkflow (`sra2fastq.wdl`) to download FASTQ files from SRA accessions, detect platform type (Illumina or PacBio), and output relevant files and metadata. The main workflow (`rqcfilter.wdl`) now imports and uses this subworkflow when SRA accessions are provided. [[1]](diffhunk://#diff-242cc0d86ef4c17f9774dc58b4cb9b81458625082df2808c76b7933df43c57ceR4-R75) [[2]](diffhunk://#diff-54e80159ab6b2d1ccbc831b42bd1ea4e016df3ad7f0d9645c55a6080096ce450R1-R86)
* Updated workflow logic to select inputs and processing steps based on whether SRA accessions or local files are provided, including automatic platform detection and an explicit error message for unsupported platforms.

**Documentation and example updates**

* Updated `README.md` and `docs/index.rst` to document the new `rqcfilter.accessions` input, describe mutually exclusive input options, and clarify expected output files when using SRA accessions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R55) [[3]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L131-R134) [[4]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R146) [[5]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R214-R218)
* Modified the example `input.json` to include the new `rqcfilter.accessions` field and adjust the format of `rqcfilter.input_files`.

**Output and naming consistency**

* Standardized main QC output file naming to use the `_filtered.fastq.gz` suffix instead of the previous naming convention.

**Bug fixes and minor improvements**

* Improved log filtering in `longReadsqc.wdl` to exclude extraneous lines from stats files. [[1]](diffhunk://#diff-8e7e7783231b856ec6545e6f256899d10af96d798155947d07cb7dff78e2e239L206-R206) [[2]](diffhunk://#diff-8e7e7783231b856ec6545e6f256899d10af96d798155947d07cb7dff78e2e239L247-R247)
* Added `trimreaddescription=t` to `reformat.sh` in `shortReadsqc.wdl` for better read description handling, and fixed a memory flag typo.

**Test runs by jaws**

Illumina PE reads: run_id=129208
Pacbio reads: run_id=129210